### PR TITLE
Update CatalogPageExtension.php

### DIFF
--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -178,8 +178,10 @@ class CatalogPageExtension extends DataExtension
      */
     public function canCreate($member)
     {
-        return count($this->getCatalogParents()) === 0
-            ? false
-            : null;
+        $catalogParents = $this->getCatalogParents();
+        if(isset($catalogParents) && count($catalogParents) === 0)
+            return false;
+        else
+            return true;
     }
 }


### PR DESCRIPTION
$this->getCatalogParents() can be NULL (if no "parent_class" has been set) or a DATALIST (SiteTree), so before to call the count() method we need to check if it's not null otherwise we get a Warning massage