### PR TITLE
Update CatalogPageAdmin.php

### DIFF
--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -101,7 +101,8 @@ abstract class CatalogPageAdmin extends ModelAdmin
             new FieldList()
         )->setHTMLID('Form_EditForm');
 
-        if (count($model->getCatalogParents()) === 0) {
+        $catalogParents = $model->getCatalogParents();
+        if( isset($catalogParents) && count($catalogParents) === 0 )
             $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
         }
 


### PR DESCRIPTION
$this->getCatalogParents() can be NULL (if no "parent_class" has been set) or a DATALIST (SiteTree), so before to call the count() method we need to check if it's not null otherwise we get a Warning message (unable to call "count" on no countable data)